### PR TITLE
Fix weak modifiers in vala code

### DIFF
--- a/src/Corebird.vala
+++ b/src/Corebird.vala
@@ -396,7 +396,7 @@ public class Corebird : Gtk.Application {
    */
   public bool is_window_open_for_screen_name (string screen_name,
                                               out MainWindow? window = null) {
-    unowned GLib.List<weak Gtk.Window> windows = this.get_windows ();
+    unowned GLib.List<Gtk.Window> windows = this.get_windows ();
     foreach (Gtk.Window win in windows) {
       if (win is MainWindow) {
         if (((MainWindow)win).account.screen_name == screen_name) {
@@ -411,7 +411,7 @@ public class Corebird : Gtk.Application {
 
   public bool is_window_open_for_user_id (int64 user_id,
                                           out MainWindow? window = null) {
-    unowned GLib.List<weak Gtk.Window> windows = this.get_windows ();
+    unowned GLib.List<Gtk.Window> windows = this.get_windows ();
     foreach (Gtk.Window win in windows) {
       if (win is MainWindow) {
         if (((MainWindow)win).account.id == user_id) {
@@ -428,7 +428,7 @@ public class Corebird : Gtk.Application {
    * Quits the application, saving all open windows and their geometries.
    */
   private void quit_application () {
-    unowned GLib.List<weak Gtk.Window> windows = this.get_windows ();
+    unowned GLib.List<Gtk.Window> windows = this.get_windows ();
     string[] startup_accounts = Settings.get ().get_strv ("startup-accounts");
     if (startup_accounts.length == 1 && startup_accounts[0] == "")
       startup_accounts.resize (0);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -435,7 +435,7 @@ public class MainWindow : Gtk.ApplicationWindow {
     if (account == null)
       return Gdk.EVENT_PROPAGATE;
 
-    unowned GLib.List<weak Gtk.Window> ws = this.application.get_windows ();
+    unowned GLib.List<Gtk.Window> ws = this.application.get_windows ();
     debug("Windows: %u", ws.length ());
 
     string[] startup_accounts = Settings.get ().get_strv ("startup-accounts");


### PR DESCRIPTION
I guess there were some changes to the vala upstream libraries, which caused it to throw a couple of conversion errors (at least on Arch Linux):

```
MainWindow.vala:438.40-438.75: error: Assignment: Cannot convert from `GLib.List<Gtk.Window>' to `GLib.List<weak Gtk.Window>?'
    unowned GLib.List<weak Gtk.Window> ws = this.application.get_windows ();
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

So I changed these according to the error messages. If anyone actually knows Vala, I'd be happy if you could review my changes. Thanks.

And since this repository is referenced in the [Arch User Repository](https://aur.archlinux.org/packages/corebird-non-streaming-git/), I think it would be a good idea to also apply the fix here.

Thanks,
Markus